### PR TITLE
few bug fixes

### DIFF
--- a/create-ssl-certs.sh
+++ b/create-ssl-certs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+mkdir -p src/ssl
+
 pushd src/ssl
 
 # create your own CA key

--- a/src/main/core/Routing.ts
+++ b/src/main/core/Routing.ts
@@ -68,10 +68,16 @@ export class Routing {
     }
 
     async serveE2E(req: Req): Promise<Res> {
+        const modifiedRequest = req.withUri(`http://localhost:${this.server.port}${req.uri.asUriString()}`);
+
         if (!this.server) return ResOf(400, 'Routing does not have a server');
+        
         await this.start();
-        const response = await HttpClient(req.withUri(`http://localhost:${this.server.port}${req.uri.asUriString()}`));
+        
+        const response = await HttpClient(modifiedRequest);
+        
         await this.stop();
+
         return response;
     }
 
@@ -84,7 +90,7 @@ export class Routing {
             return next(prev)
         }, matchedHandler.handler);
 
-        return filteringHandler(req.withPathParamsFromTemplate(matchedHandler.path));
+        return filteringHandler(req.withPathParamsFromTemplate(matchedHandler.path)).catch(e => ResOf(500));
     }
 
     match(req: Req): Route | undefined {

--- a/src/main/core/Routing.ts
+++ b/src/main/core/Routing.ts
@@ -70,7 +70,7 @@ export class Routing {
     async serveE2E(req: Req): Promise<Res> {
         if (!this.server) return ResOf(400, 'Routing does not have a server');
         await this.start();
-        const response = await HttpClient(req.withUri(`http://localhost:${this.server.port}${req.uri.path()}`));
+        const response = await HttpClient(req.withUri(`http://localhost:${this.server.port}${req.uri.asUriString()}`));
         await this.stop();
         return response;
     }

--- a/src/test/core/RoutingSpec.ts
+++ b/src/test/core/RoutingSpec.ts
@@ -391,6 +391,16 @@ describe('routing', async () => {
         equal(response.bodyString(), '{"phil":"reallycool"}');
     });
 
+    it('serves 500 on handler exception', async () => {
+        const response = await get('/', async () => {
+            throw new Error('BANG!');
+            return ResOf(500, 'internal server error');
+        })
+            .asServer(HttpServer(3004))
+            .serveE2E(ReqOf('GET', '/'));
+        equal(response.status, 500);
+    });
+
     it('res body is a stream if req body is a stream', async () => {
         const readable = new Readable({read(){}});
         readable.push('some body');

--- a/src/test/core/RoutingSpec.ts
+++ b/src/test/core/RoutingSpec.ts
@@ -385,9 +385,10 @@ describe('routing', async () => {
     });
 
     it('serves a request e2e if you have a server attached', async () => {
-        const response = await get('/', async() => ResOf()).asServer(HttpServer(3004))
-            .serveE2E(ReqOf('GET', '/'));
+        const response = await get('/', async (req: Req) => ResOf(200, JSON.stringify(req.queries))).asServer(HttpServer(3004))
+            .serveE2E(ReqOf('GET', '/?phil=reallycool'));
         equal(response.status, 200);
+        equal(response.bodyString(), '{"phil":"reallycool"}');
     });
 
     it('res body is a stream if req body is a stream', async () => {

--- a/src/test/servers/HttpServerSpec.ts
+++ b/src/test/servers/HttpServerSpec.ts
@@ -13,7 +13,7 @@ describe("native node over the wire", () => {
     const baseUrl = "http://localhost:" + port;
 
     const server = get("/", async(req) => {
-        const query = req.query("tomQuery");
+        const query = req.query("tomQuery") as string;
         return ResOf(200, req.bodyString())
             .withHeaders(req.headers)
             .withHeader("tomQuery", query || "no tom query");


### PR DESCRIPTION
- [FIX]: missing ssl directory on initial clone
- [FIX]: `Routing.serveE2E` not including full request URI
- [FIX]: `Routing.serve` not handling uncaught exceptions - now returns a 500 response on the event of uncaught exception